### PR TITLE
Update to GNOME 40

### DIFF
--- a/org.gnome.design.AppIconPreview.json
+++ b/org.gnome.design.AppIconPreview.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.gnome.design.AppIconPreview",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.36",
+  "runtime-version": "40",
   "sdk": "org.gnome.Sdk",
   "command": "app-icon-preview",
   "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],


### PR DESCRIPTION
Libhandy must stay on 0.13, runtime-included version is too new.

@bilelmoussaoui I even included a fabulous test screenshot:

![Screenshot from 2021-03-27 13-59-48](https://user-images.githubusercontent.com/33983090/112721625-2dbe8080-8f05-11eb-90db-a240e484905f.png)
