### PR TITLE
Update Runtime Version to 48

### DIFF
--- a/org.gnome.design.AppIconPreview.json
+++ b/org.gnome.design.AppIconPreview.json
@@ -1,7 +1,7 @@
 {
   "id": "org.gnome.design.AppIconPreview",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "command": "app-icon-preview",
   "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],


### PR DESCRIPTION
Update runtime version to GNOME 48; should affect dark theme coloration and corner radius of window and some widgets (due to Libadwaita 1.7)